### PR TITLE
Attack of the .DS_Store files halted.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ eclipse
 lib
 .classpath
 .project
+
+#mac
+.DS_Store


### PR DESCRIPTION
This is so mac users like me can send pull requests without the .DS_Store file that are auto-generatored by OS-X, since most people don't like those. See: http://en.wikipedia.org/wiki/.DS_Store
